### PR TITLE
Feat/#2 user refresh token

### DIFF
--- a/src/main/java/com/example/beginnerfitbe/jwt/config/SecurityConfig.java
+++ b/src/main/java/com/example/beginnerfitbe/jwt/config/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
     private static final String[] publicEndpoints = {
             "/auth/sign-in",
             "/auth/sign-up",
+            "/auth/refresh",
             "/auth/email-send",
             "/auth/email-verify",
             "/auth/find-id",

--- a/src/main/java/com/example/beginnerfitbe/jwt/util/JwtUtil.java
+++ b/src/main/java/com/example/beginnerfitbe/jwt/util/JwtUtil.java
@@ -86,9 +86,21 @@ public class JwtUtil {
     }
 
     public void validateRefreshToken(String email, String refreshToken) {
-        String redisRefreshToken = redisService.getData(email);
-        if (!refreshToken.equals(redisRefreshToken)) {
-            throw new IllegalArgumentException("유저 정보 일치 x");
+        String storedRefreshToken = redisService.getData(email);
+
+        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
+            throw new IllegalArgumentException("Invalid refresh token");
+        }
+        // refreshToken의 유효성 검사
+        try {
+            Claims claims = Jwts.parser()
+                    .setSigningKey(secretKey.getBytes())
+                    .parseClaimsJws(refreshToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new IllegalArgumentException("Expired refresh token");
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid refresh token");
         }
     }
 

--- a/src/main/java/com/example/beginnerfitbe/jwt/util/JwtUtil.java
+++ b/src/main/java/com/example/beginnerfitbe/jwt/util/JwtUtil.java
@@ -112,4 +112,15 @@ public class JwtUtil {
         Claims claims = parseClaims(token);
         return claims.get("userId", Long.class);
     }
+
+    public boolean deleteRegisterToken(String email){
+        try{
+            if(redisService.hasKey(email)){
+                redisService.deleteData(email);
+                return true;
+            }
+        }
+        catch (Exception e){e.printStackTrace();}
+        return false;
+    }
 }

--- a/src/main/java/com/example/beginnerfitbe/redis/service/RedisService.java
+++ b/src/main/java/com/example/beginnerfitbe/redis/service/RedisService.java
@@ -28,4 +28,8 @@ public class RedisService {
     public void deleteData(String key){
         redisTemplate.delete(key);
     }
+
+    public boolean hasKey(String key) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
 }

--- a/src/main/java/com/example/beginnerfitbe/redis/service/RedisService.java
+++ b/src/main/java/com/example/beginnerfitbe/redis/service/RedisService.java
@@ -6,6 +6,7 @@ import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -31,5 +32,15 @@ public class RedisService {
 
     public boolean hasKey(String key) {
         return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    public String getEmailByRefreshToken(String refreshToken) {
+        Set<String> keys = redisTemplate.keys("*");
+        for (String key : keys) {
+            if (refreshToken.equals(redisTemplate.opsForValue().get(key))) {
+                return key;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/com/example/beginnerfitbe/user/controller/AuthController.java
+++ b/src/main/java/com/example/beginnerfitbe/user/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.example.beginnerfitbe.user.dto.SignInReqDto;
 import com.example.beginnerfitbe.user.dto.SignUpReqDto;
 import com.example.beginnerfitbe.user.service.AuthService;
 import com.example.beginnerfitbe.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -38,6 +39,13 @@ public class AuthController {
         String password = resetPasswordDto.getPassword();
         return ResponseEntity.ok(authService.resetPassword(email, password));
     }
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refresh(
+            @RequestHeader("X-Access-Token") String accessToken,
+            @RequestHeader("X-Refresh-Token") String refreshToken
 
+    ) {
+        return ResponseEntity.ok(authService.refresh(accessToken, refreshToken));
+    }
 
 }

--- a/src/main/java/com/example/beginnerfitbe/user/controller/AuthController.java
+++ b/src/main/java/com/example/beginnerfitbe/user/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.example.beginnerfitbe.user.controller;
 
 import com.example.beginnerfitbe.error.StateResponse;
+import com.example.beginnerfitbe.jwt.util.JwtUtil;
 import com.example.beginnerfitbe.user.dto.ResetPasswordDto;
 import com.example.beginnerfitbe.user.dto.SignInReqDto;
 import com.example.beginnerfitbe.user.dto.SignUpReqDto;
@@ -20,6 +21,7 @@ import java.io.IOException;
 public class AuthController {
     private final AuthService authService;
     private final UserService userService;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/sign-up")
     public ResponseEntity<?> signUp(@RequestBody SignUpReqDto dto) throws IOException {
@@ -43,14 +45,18 @@ public class AuthController {
     }
     @PostMapping("/refresh")
     public ResponseEntity<?> refresh(
-            @RequestHeader("X-Access-Token") String accessToken,
-            @RequestHeader("X-Refresh-Token") String refreshToken
+            @RequestHeader("Authorization") String refreshToken
 
     ) {
-        return ResponseEntity.ok(authService.refresh(accessToken, refreshToken));
+        // Bearer 접두사를 제거
+        if (refreshToken.startsWith("Bearer ")) {
+            refreshToken = refreshToken.substring(7);
+        }
+        return ResponseEntity.ok(authService.refresh(refreshToken));
     }
-    @PostMapping("/sign-out/{userId}")
-    public ResponseEntity<?> signOut(@PathVariable Long userId) {
+    @PostMapping("/sign-out")
+    public ResponseEntity<?> signOut(HttpServletRequest request) {
+        Long userId = jwtUtil.getUserId(jwtUtil.resolveToken(request).substring(7));
         return ResponseEntity.ok(authService.signOut(userId));
     }
 

--- a/src/main/java/com/example/beginnerfitbe/user/controller/AuthController.java
+++ b/src/main/java/com/example/beginnerfitbe/user/controller/AuthController.java
@@ -54,7 +54,7 @@ public class AuthController {
         }
         return ResponseEntity.ok(authService.refresh(refreshToken));
     }
-    @PostMapping("/sign-out")
+    @GetMapping("/sign-out")
     public ResponseEntity<?> signOut(HttpServletRequest request) {
         Long userId = jwtUtil.getUserId(jwtUtil.resolveToken(request).substring(7));
         return ResponseEntity.ok(authService.signOut(userId));

--- a/src/main/java/com/example/beginnerfitbe/user/controller/AuthController.java
+++ b/src/main/java/com/example/beginnerfitbe/user/controller/AuthController.java
@@ -1,11 +1,13 @@
 package com.example.beginnerfitbe.user.controller;
 
+import com.example.beginnerfitbe.error.StateResponse;
 import com.example.beginnerfitbe.user.dto.ResetPasswordDto;
 import com.example.beginnerfitbe.user.dto.SignInReqDto;
 import com.example.beginnerfitbe.user.dto.SignUpReqDto;
 import com.example.beginnerfitbe.user.service.AuthService;
 import com.example.beginnerfitbe.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -46,6 +48,10 @@ public class AuthController {
 
     ) {
         return ResponseEntity.ok(authService.refresh(accessToken, refreshToken));
+    }
+    @PostMapping("/sign-out/{userId}")
+    public ResponseEntity<?> signOut(@PathVariable Long userId) {
+        return ResponseEntity.ok(authService.signOut(userId));
     }
 
 }

--- a/src/main/java/com/example/beginnerfitbe/user/dto/SignInResDto.java
+++ b/src/main/java/com/example/beginnerfitbe/user/dto/SignInResDto.java
@@ -9,5 +9,6 @@ import lombok.Getter;
 public class SignInResDto {
     private Long userId;
     private String accessToken;
+    private String refreshToken;
 }
 

--- a/src/main/java/com/example/beginnerfitbe/user/dto/UserDto.java
+++ b/src/main/java/com/example/beginnerfitbe/user/dto/UserDto.java
@@ -55,5 +55,4 @@ public class UserDto {
         );
     }
 
-
 }

--- a/src/main/java/com/example/beginnerfitbe/user/service/AuthService.java
+++ b/src/main/java/com/example/beginnerfitbe/user/service/AuthService.java
@@ -123,5 +123,28 @@ public class AuthService {
         );
     }
 
+    public StateResponse signOut(Long userId) {
+        UserDto userDto = userService.read(userId);
+        if (userDto != null) {
+            boolean tokenDeleted = jwtUtil.deleteRegisterToken(userDto.getEmail());
+            if (tokenDeleted) {
+                return StateResponse.builder()
+                        .code("SUCCESSFUL")
+                        .message("로그아웃 되었습니다.")
+                        .build();
+            } else {
+                return StateResponse.builder()
+                        .code("FAILED")
+                        .message("로그아웃 실패. 토큰 삭제에 실패했습니다.")
+                        .build();
+            }
+        } else {
+            return StateResponse.builder()
+                    .code("FAILED")
+                    .message("사용자를 찾을 수 없습니다.")
+                    .build();
+        }
+    }
+
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,7 +46,8 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET}
-  expiration: ${JWT_EXPIRATION}
+  accessExpiration: ${JWT_ACCESS_EXPIRATION}
+  refreshExpiration: ${JWT_REFRESH_EXPIRATION}
   issuer: ${JWT_ISSUER}
 
 cloud:


### PR DESCRIPTION
### ✏️ Feat

로그인 시 refreshToken도 발급, 토큰 재발급, 로그아웃 기능 구현했습니다.

`refresh`
authorization에 refresh 토큰을 받고, redis에 담긴 정보와 비교하여 검증되면 토큰을 재발급합니다.
refresh는 재발급 하지 않고, 똑같은 걸로 반환합니다.

`sign-out`
redis에서 refresh토큰을 제거합니다. 프론트는 로컬 스토리지에 담긴 토큰을 제거합니다.

feat/#2-user-refreshToken -> `dev`

Issue #2 